### PR TITLE
Update local_settings_gaz.py.j2

### DIFF
--- a/roles/gazetteer/files/local_settings_gaz.py.j2
+++ b/roles/gazetteer/files/local_settings_gaz.py.j2
@@ -5,7 +5,7 @@
 # but leave it free to have a separate server for RDF!
 SITEURL='{{ host }}'
 
-RDFSERVER=SITEURL[:-1]
+RDFSERVER="".join((SITEURL[:-1],":8080"))
     
 GAZ_APPS = (
    
@@ -22,12 +22,12 @@ INSTALLED_APPS += GAZ_APPS
 # RDF triplestore settings
 RDFSTORE_RDF4J = {
     'default' : {
-        'server' : "".join((RDFSERVER,":8080/rdf4j-server/repositories/gaz" )),
+        'server' : "".join((RDFSERVER,"/rdf4j-server/repositories/gaz" )),
         'server_api' : "RDF4JREST",
         # model and slug are special - slug will revert to id if not present
         'target' : "/statements?context=<{model}>",
         # this should be pulled from settings
-        'sparql' : "".join((RDFSERVER,":8080/rdf4j-server/repositories/gaz" ))
+        'sparql' : "".join((RDFSERVER,"/rdf4j-server/repositories/gaz" ))
         },
     'scheme' : {
         'target' : "/statements?context=<{uri}>",


### PR DESCRIPTION
removed assumption that server on port 8080 and moved that to the RDFSTORE URL setting - which we reuse elsewhere to find the ELDA.
(can remove :8080 if django setup to redirect /dna /rdf-server uri patterns...)